### PR TITLE
layer.conf files: Add Yocto wrynose release to LAYERSERIES_COMPAT

### DIFF
--- a/meta-nxp-connectivity-examples/conf/layer.conf
+++ b/meta-nxp-connectivity-examples/conf/layer.conf
@@ -3,7 +3,7 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_nxp-connectivity-examples = "styhead walnascar whinlatter"
+LAYERSERIES_COMPAT_nxp-connectivity-examples = "styhead walnascar whinlatter wrynose"
 
 IMAGE_INSTALL:append = " zigbee-coordinator matter-ncp "
 IMAGE_INSTALL:append = " ${@bb.utils.contains_any('TUNE_FEATURES', 'armv8 armv8a', 'easymesh', '', d)} "

--- a/meta-nxp-matter-advanced/conf/layer.conf
+++ b/meta-nxp-matter-advanced/conf/layer.conf
@@ -3,7 +3,7 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_nxp-matter-advanced = "styhead walnascar whinlatter"
+LAYERSERIES_COMPAT_nxp-matter-advanced = "styhead walnascar whinlatter wrynose"
 
 IMAGE_INSTALL:append = " ${@bb.utils.contains('MACHINE_FEATURES', 'trusty', 'storageproxyd', '', d)} "
 IMAGE_INSTALL:append = " avahi-utils"

--- a/meta-nxp-matter-baseline/conf/layer.conf
+++ b/meta-nxp-matter-baseline/conf/layer.conf
@@ -3,7 +3,7 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_nxp-matter-baseline = "styhead walnascar whinlatter"
+LAYERSERIES_COMPAT_nxp-matter-baseline = "styhead walnascar whinlatter wrynose"
 
 BBFILE_COLLECTIONS += "nxp-matter-baseline"
 BBFILE_PATTERN_nxp-matter-baseline = "^${LAYERDIR}/"

--- a/meta-nxp-openthread/conf/layer.conf
+++ b/meta-nxp-openthread/conf/layer.conf
@@ -4,7 +4,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_nxp-openthread = "styhead walnascar whinlatter "
+LAYERSERIES_COMPAT_nxp-openthread = "styhead walnascar whinlatter wrynose"
 
 BBFILE_COLLECTIONS += "nxp-openthread"
 BBFILE_PATTERN_nxp-openthread = "^${LAYERDIR}/"

--- a/meta-nxp-otbr/conf/layer.conf
+++ b/meta-nxp-otbr/conf/layer.conf
@@ -4,7 +4,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bb \
             ${LAYERDIR}/recipes-*/*/*.bbappend"
 
-LAYERSERIES_COMPAT_nxp-otbr = "styhead walnascar whinlatter"
+LAYERSERIES_COMPAT_nxp-otbr = "styhead walnascar whinlatter wrynose"
 
 BBFILE_COLLECTIONS += "nxp-otbr"
 BBFILE_PATTERN_nxp-otbr = "^${LAYERDIR}/"

--- a/meta-nxp-zigbee-rcp/conf/layer.conf
+++ b/meta-nxp-zigbee-rcp/conf/layer.conf
@@ -4,7 +4,7 @@ BBFILES += "${LAYERDIR}/*.bb \
             ${LAYERDIR}/recipes-*/*.bb \
             ${LAYERDIR}/recipes-*/*.bbappend"
 
-LAYERSERIES_COMPAT_nxp-zigbee-rcp = "styhead walnascar whinlatter"
+LAYERSERIES_COMPAT_nxp-zigbee-rcp = "styhead walnascar whinlatter wrynose"
 
 BBFILE_COLLECTIONS += "nxp-zigbee-rcp"
 BBFILE_PATTERN_nxp-zigbee-rcp = "^${LAYERDIR}/"


### PR DESCRIPTION
Upstream core layers master branches have switched to wrynose for upcoming Yocto 6.0 LTS